### PR TITLE
Fix gulp crashes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,6 +44,9 @@ gulp.task(TASKS.BUILD, [ TASKS.CLEAN ], function() {
       insertGlobals : true,
       debug : true
     }))
+    .on('error', ({ stack }) =>
+      console.error(stack)
+    )
     .pipe(
       babel({ presets: [ 'stage-3' ] })
     )

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "main.js",
   "scripts": {
-    "start": "gulp build && open index.html && gulp",
+    "start": "gulp build && open index.html && gulp watch",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
This will remove the need to restart gulp if any js files are accidentally saved with parse errors in them.